### PR TITLE
Upgrade to 4.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - async-timeout >=4.0.2
     - deprecated >=1.2.3
+    - importlib-metadata >=1.0
     - packaging >=20.4
     - typing-extensions
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,24 +11,34 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True # [py<36]
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - async-timeout >=4.0.2
     - deprecated >=1.2.3
-    - importlib-metadata >=1.0
+    - importlib-metadata >=1.0 # [py<38]
+    - typing-extensions        # [py<38]
     - packaging >=20.4
-    - typing-extensions
 
 test:
   commands:
     - pip check
   imports:
     - redis
+    - redis.asyncio
+    - redis.commands
+    - redis.commands.bf
+    - redis.commands.json
+    - redis.commands.search
+    - redis.commands.timeseries
+    - redis.commands.graph
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - async-timeout >=4.0.2
     - deprecated >=1.2.3
+    - packaging >=20.4
     - typing-extensions
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.5.3" %}
+{% set version = "4.3.4" %}
 
 package:
   name: redis-py
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/andymccurdy/redis-py/archive/{{ version }}.tar.gz
-  sha256: 0e3ef04af57d17207c2f13a49641a63b98e0040a10756a8247e833468b5a8206
+  sha256: a3d3b6e86cc73c253fd5c02d174098abf3fa043dfdcb29689eb928f60a552fd6
 
 build:
   number: 0
@@ -19,6 +19,9 @@ requirements:
     - pip
   run:
     - python
+    - async-timeout >=4.0.2
+    - deprecated >=1.2.3
+    - typing-extensions
 
 test:
   commands:
@@ -27,12 +30,11 @@ test:
     - redis
   requires:
     - pip
-    - pytest >=2.5.0
 
 about:
-  home: https://github.com/andymccurdy/redis-py/
+  home: https://github.com/redis/redis-py/
   license: MIT
-  license_url: https://github.com/andymccurdy/redis-py/blob/master/LICENSE
+  license_url: https://github.com/redis/redis-py/blob/master/LICENSE
   license_family: MIT
   license_file: LICENSE
   summary: Python client for Redis key-value store
@@ -40,9 +42,8 @@ about:
     The Python interface to the Redis key-value store. Requires a running
     Redis server.
   doc_url: https://pypi.python.org/pypi/redis
-  doc_source_url: https://github.com/andymccurdy/redis-py/blob/master/README.rst
-  dev_url: https://github.com/andymccurdy/redis-py/
-
+  doc_source_url: https://github.com/redis/redis-py/blob/master/README.md
+  dev_url: https://github.com/redis/redis-py/
 extra:
   recipe-maintainers:
     - kwilcox

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,12 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/andymccurdy/redis-py/archive/{{ version }}.tar.gz
+  url: https://github.com/redis/redis-py/archive/v{{ version }}.tar.gz
   sha256: a3d3b6e86cc73c253fd5c02d174098abf3fa043dfdcb29689eb928f60a552fd6
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
`redis-py > 4` is recommended for connecting to `redis-server > 6`, so for `ray` and other newer packages requiring such a recent version of `redis` will need a newer version of `redis-py`; currently this is the newest.