### PR TITLE
update to 5.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - hiredis >=3.0.0
     - cryptography >=36.0.1
     - requests >=2.31.0
+    - pyopenssl >=23.2.1
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.4" %}
+{% set version = "5.2.0" %}
 
 package:
   name: redis-py
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/redis/redis-py/archive/v{{ version }}.tar.gz
-  sha256: a3d3b6e86cc73c253fd5c02d174098abf3fa043dfdcb29689eb928f60a552fd6
+  sha256: 9be14a8c988a0428c942b8eda201bb2ed2ea6ff7c05a07bbede45b1e1b60d19c
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True # [py<38]
 
 requirements:
   host:
@@ -21,11 +21,11 @@ requirements:
     - wheel
   run:
     - python
-    - async-timeout >=4.0.2
-    - deprecated >=1.2.3
-    - importlib-metadata >=1.0 # [py<38]
-    - typing-extensions        # [py<38]
-    - packaging >=20.4
+    - async-timeout >=4.0.3 # [py<312]
+  run_constrained:
+    - hiredis >=3.0.0
+    - cryptography >=36.0.1
+    - requests >=2.31.0
 
 test:
   commands:


### PR DESCRIPTION
redis-py 5.2.0

**Destination channel:** main

### Links

- PKG-5313
- https://github.com/redis/redis-py/tree/v5.2.0

Not setting pyopenssl in run_constrained because constraint is too strict.