### PR TITLE
redis-py 7.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,16 +18,17 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - python
-    - async-timeout >=4.0.3 # [py<312]
+    - async-timeout >=4.0.3
   run_constrained:
-    - hiredis >=3.0.0
+    - hiredis >=3.2.0
     - cryptography >=36.0.1
+    - pyopenssl >=20.0.1
     - requests >=2.31.0
-    - pyopenssl >=23.2.1
+    - pyjwt >=2.9.0
+    - pybreaker >=1.4.0
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "5.2.0" %}
+{% set name = "redis-py" %}
+{% set version = "7.0.1" %}
 
 package:
-  name: redis-py
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/redis/redis-py/archive/v{{ version }}.tar.gz
-  sha256: 9be14a8c988a0428c942b8eda201bb2ed2ea6ff7c05a07bbede45b1e1b60d19c
+  url: https://github.com/redis/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 81c2b08d544f101c22adc15277704d5dde23dabab91a6bb3b993b0b659d418b2
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,19 +36,21 @@ test:
   imports:
     - redis
     - redis.asyncio
+    - redis.auth
     - redis.commands
     - redis.commands.bf
     - redis.commands.json
     - redis.commands.search
     - redis.commands.timeseries
-    - redis.commands.graph
+    - redis.commands.vectorset
+    - redis.http
+    - redis.multidb
   requires:
     - pip
 
 about:
   home: https://github.com/redis/redis-py/
   license: MIT
-  license_url: https://github.com/redis/redis-py/blob/master/LICENSE
   license_family: MIT
   license_file: LICENSE
   summary: Python client for Redis key-value store
@@ -56,7 +58,6 @@ about:
     The Python interface to the Redis key-value store. Requires a running
     Redis server.
   doc_url: https://pypi.python.org/pypi/redis
-  doc_source_url: https://github.com/redis/redis-py/blob/master/README.md
   dev_url: https://github.com/redis/redis-py/
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
 
 test:
   commands:
+    # pytest tests unavailable since 'pybreaker' is unavailable
     - pip check
   imports:
     - redis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True # [py<38]
+  skip: True # [py<39]
 
 requirements:
   host:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10466](https://anaconda.atlassian.net/browse/PKG-10466)
- [Upstream repository](https://github.com/redis/redis-py/tree/v7.0.1)
- [Upstream changelog/diff](https://github.com/redis/redis-py/releases)

### Explanation of changes:

- New version number and sha256
- Python version skip updated to <39
- Jinja templating added
- Dependencies updated according to upstream requirements
- Test import updates 
- Linter fixes


[PKG-10466]: https://anaconda.atlassian.net/browse/PKG-10466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ